### PR TITLE
Removes invalid `new` for Response.redirect

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -53,5 +53,5 @@ async function handleRequest(request) {
     return submitHandler(request)
   }
 
-  return new Response.redirect(FORM_URL)
+  return Response.redirect(FORM_URL)
 }


### PR DESCRIPTION
The keyword `new` before `Response.redirect` raises a Javascript exception since the function is not a constructor.

You can reproduce an error in the deployed code of the worker by accessing: https://workers-airtable-form.signalnerve.workers.dev

It should redirect to https://airtable-form-example.pages.dev but instead raises an exception.-

I also opened a documentation issue https://github.com/cloudflare/cloudflare-docs/issues/2505 to address this typo.